### PR TITLE
menu loses context

### DIFF
--- a/src/reagent_contextmenu/menu.cljs
+++ b/src/reagent_contextmenu/menu.cljs
@@ -161,7 +161,6 @@
                                (hide-context!)
                                (.preventDefault e))
             :on-key-up esc-handler!
-            :tab-index -1
             :ref #(some-> % (.focus))}
       (when display [backdrop hide-context!])
       (when display
@@ -189,11 +188,5 @@
    [my-other-fn #(prn (str 1 2 3))]]"
   ([evt name-fn-coll] (context! evt default-menu-atom name-fn-coll))
   ([evt menu-atom name-fn-coll]
-   (show-context! menu-atom name-fn-coll 
-                  (- (.-pageX evt) ;; absolute position
-                     (- (.-pageX evt) ;; scrolled
-                        (.-clientX evt)))
-                  (- (.-pageY evt) ;; absolute position
-                     (- (.-pageY evt) ;; scrolled
-                        (.-clientY evt))))
+   (show-context! menu-atom name-fn-coll (.-pageX evt) (.-pageY evt))
    (.preventDefault evt)))


### PR DESCRIPTION
I've been trying reagent-contextmenu in an application that has a simple table that can span beyond the size of the window, hence the user needs to scroll down.
When right-clicking down below, the page gets automatically scrolled back to the top and the context of the menu is lost.
The patch I'm proposing fixes that behaviour but it hasn't been tested on anything but that application and might as well break other user interfaces.
